### PR TITLE
Add more new ZonedDateTime methods

### DIFF
--- a/src/main/kotlin/YearUtil.kt
+++ b/src/main/kotlin/YearUtil.kt
@@ -1,0 +1,10 @@
+
+object YearUtil {
+    fun isLeapYear(year: Int): Boolean =
+        when {
+            year % 4 != 0 -> false
+            year % 400 == 0 -> true
+            year % 100 == 0 -> false
+            else -> true
+        }
+}

--- a/src/main/kotlin/localdate/extensions/LocalDateAttributeExtensions.kt
+++ b/src/main/kotlin/localdate/extensions/LocalDateAttributeExtensions.kt
@@ -1,9 +1,8 @@
 package localdate.extensions
 
-import zoneddatetime.ZonedDateTimeUtil
 import java.time.LocalDate
 
-fun LocalDate.isInLeapYear(): Boolean = ZonedDateTimeUtil.isLeapYear(this.year)
+fun LocalDate.isInLeapYear(): Boolean = YearUtil.isLeapYear(this.year)
 
 fun LocalDate.getMonthBaseZero(): Int = this.monthValue - 1
 

--- a/src/main/kotlin/localdatetime/extensions/LocalDateTimeAttributeExtensions.kt
+++ b/src/main/kotlin/localdatetime/extensions/LocalDateTimeAttributeExtensions.kt
@@ -1,9 +1,8 @@
 package localdatetime.extensions
 
-import zoneddatetime.ZonedDateTimeUtil
 import java.time.LocalDateTime
 
-fun LocalDateTime.isInLeapYear(): Boolean = ZonedDateTimeUtil.isLeapYear(this.year)
+fun LocalDateTime.isInLeapYear(): Boolean = YearUtil.isLeapYear(this.year)
 
 fun LocalDateTime.isAtStartOfDay(): Boolean = this.isEqualTime(this.atStartOfDay())
 

--- a/src/main/kotlin/zoneddatetime/ZonedDateTimeUtil.kt
+++ b/src/main/kotlin/zoneddatetime/ZonedDateTimeUtil.kt
@@ -5,8 +5,12 @@ import java.time.LocalDateTime
 import java.time.Month
 import java.time.ZoneId
 import java.time.ZonedDateTime
+import java.util.Calendar
+import java.util.Date
 
 object ZonedDateTimeUtil {
+
+    private val UTC get() = ZoneId.of("UTC")
 
     fun new(
         year: Int,
@@ -15,7 +19,8 @@ object ZonedDateTimeUtil {
         hourIn24: Int = 0,
         minute: Int = 0,
         second: Int = 0,
-        nano: Int = 0
+        nano: Int = 0,
+        useSystemTimeZone: Boolean = true
     ): ZonedDateTime {
         val localDateTime = LocalDateTime.of(
             year,
@@ -26,7 +31,10 @@ object ZonedDateTimeUtil {
             second,
             nano
         )
-        return ZonedDateTime.of(localDateTime, ZoneId.systemDefault())
+        return ZonedDateTime.of(
+            localDateTime,
+            if (useSystemTimeZone) ZoneId.systemDefault() else UTC
+        )
     }
 
     fun new(
@@ -37,7 +45,8 @@ object ZonedDateTimeUtil {
         minute: Int = 0,
         second: Int = 0,
         nano: Int = 0,
-        isAm: Boolean
+        isAm: Boolean,
+        useSystemTimeZone: Boolean = true
     ): ZonedDateTime {
         val localDateTime = LocalDateTime.of(
             year,
@@ -48,16 +57,28 @@ object ZonedDateTimeUtil {
             second,
             nano
         )
-        return ZonedDateTime.of(localDateTime, ZoneId.systemDefault())
+        return ZonedDateTime.of(
+            localDateTime,
+            if (useSystemTimeZone) ZoneId.systemDefault() else UTC
+        )
     }
 
-    fun new(millis: Long): ZonedDateTime = Instant.ofEpochMilli(millis).atZone(ZoneId.systemDefault())
+    fun new(millis: Long, useSystemTimeZone: Boolean = true): ZonedDateTime =
+        getZonedDateTimeFromInstant(Instant.ofEpochMilli(millis), useSystemTimeZone)
 
-    fun isLeapYear(year: Int): Boolean =
-        when {
-            year % 4 != 0 -> false
-            year % 400 == 0 -> true
-            year % 100 == 0 -> false
-            else -> true
+    fun new(date: Date, useSystemTimeZone: Boolean = true): ZonedDateTime =
+        getZonedDateTimeFromInstant(date.toInstant(), useSystemTimeZone)
+
+    fun new(calendar: Calendar, useSystemTimeZone: Boolean = true): ZonedDateTime {
+        if (useSystemTimeZone) {
+            return getZonedDateTimeFromInstant(calendar.toInstant(), true)
         }
+        return ZonedDateTime.ofInstant(calendar.toInstant(), ZoneId.of(calendar.timeZone.id))
+    }
+
+    private fun getZonedDateTimeFromInstant(instant: Instant, useSystemTimeZone: Boolean): ZonedDateTime =
+        ZonedDateTime.ofInstant(
+            instant,
+            if (useSystemTimeZone) ZoneId.systemDefault() else UTC
+        )
 }

--- a/src/main/kotlin/zoneddatetime/ZonedDateTimeUtil.kt
+++ b/src/main/kotlin/zoneddatetime/ZonedDateTimeUtil.kt
@@ -8,10 +8,25 @@ import java.time.ZonedDateTime
 import java.util.Calendar
 import java.util.Date
 
+/**
+ * ZonedDateTimeUtil object contains helper functions that only serve to create new ZonedDateTimes.
+ * Creation methods do not include parsing methods.
+ */
 object ZonedDateTimeUtil {
 
     private val UTC get() = ZoneId.of("UTC")
 
+    /**
+     * @param year  Year, ie, 2020.
+     * @param month  Month with range 1-12, i.e. 1 for January.
+     * @param day  Day of the month with range 1-31.
+     * @param hourIn24  Hour of the day with range 0-23.
+     * @param minute  Minute of the hour with range 0-59.
+     * @param second  Second of the minute with range 0-59.
+     * @param nano  Nano of the second.
+     * @param useSystemTimeZone  If true, sets the time zone of the device, else UTC.
+     * @return  ZonedDateTime.
+     */
     fun new(
         year: Int,
         month: Int,
@@ -31,44 +46,57 @@ object ZonedDateTimeUtil {
             second,
             nano
         )
-        return ZonedDateTime.of(
-            localDateTime,
-            if (useSystemTimeZone) ZoneId.systemDefault() else UTC
-        )
+        return ZonedDateTime.of(localDateTime, if (useSystemTimeZone) ZoneId.systemDefault() else UTC)
     }
 
+    /**
+     * @param year  Year, ie, 2020.
+     * @param month  Month with range 1-12, i.e. 1 for January.
+     * @param day  Day of the month with range 1-31.
+     * @param hour  Hour of the day with range 1-12.
+     * @param isAm  If true, sets assumes hour is in the AM, else PM.
+     * @param minute  Minute of the hour with range 0-59.
+     * @param second  Second of the minute with range 0-59.
+     * @param nano  Nano of the second.
+     * @param useSystemTimeZone  If true, sets the time zone of the device, else UTC.
+     * @return  ZonedDateTime.
+     */
     fun new(
         year: Int,
         month: Int,
         day: Int,
         hour: Int = 0,
+        isAm: Boolean,
         minute: Int = 0,
         second: Int = 0,
         nano: Int = 0,
-        isAm: Boolean,
         useSystemTimeZone: Boolean = true
-    ): ZonedDateTime {
-        val localDateTime = LocalDateTime.of(
-            year,
-            Month.of(month),
-            day,
-            if (isAm) hour else hour + 12,
-            minute,
-            second,
-            nano
+    ): ZonedDateTime =
+        new(
+            year, month, day, if (isAm) hour else hour + 12, minute, second, nano, useSystemTimeZone
         )
-        return ZonedDateTime.of(
-            localDateTime,
-            if (useSystemTimeZone) ZoneId.systemDefault() else UTC
-        )
-    }
 
-    fun new(millis: Long, useSystemTimeZone: Boolean = true): ZonedDateTime =
-        getZonedDateTimeFromInstant(Instant.ofEpochMilli(millis), useSystemTimeZone)
+    /**
+     * @param epochMilliseconds  Epoch time, aka Unix time, are seconds elapsed since January 1st 1970 at 00:00:00 UTC.
+     * @param useSystemTimeZone  If true, converts to time zone of the device, else leaves as UTC.
+     * @return  ZonedDateTime.
+     */
+    fun new(epochMilliseconds: Long, useSystemTimeZone: Boolean = true): ZonedDateTime =
+        getZonedDateTimeFromInstant(Instant.ofEpochMilli(epochMilliseconds), useSystemTimeZone)
 
+    /**
+     * @param date  A wrapper of Epoch time in UTC.
+     * @param useSystemTimeZone  If true, converts to time zone of the device, else leaves as UTC.
+     * @return  ZonedDateTime.
+     */
     fun new(date: Date, useSystemTimeZone: Boolean = true): ZonedDateTime =
         getZonedDateTimeFromInstant(date.toInstant(), useSystemTimeZone)
 
+    /**
+     * @param calendar  Calendar, a date time variable that supports time zones.
+     * @param useSystemTimeZone  If true, converts to time zone of the device, else leaves as is on calendar.
+     * @return  ZonedDateTime.
+     */
     fun new(calendar: Calendar, useSystemTimeZone: Boolean = true): ZonedDateTime {
         if (useSystemTimeZone) {
             return getZonedDateTimeFromInstant(calendar.toInstant(), true)
@@ -77,8 +105,5 @@ object ZonedDateTimeUtil {
     }
 
     private fun getZonedDateTimeFromInstant(instant: Instant, useSystemTimeZone: Boolean): ZonedDateTime =
-        ZonedDateTime.ofInstant(
-            instant,
-            if (useSystemTimeZone) ZoneId.systemDefault() else UTC
-        )
+        ZonedDateTime.ofInstant(instant, if (useSystemTimeZone) ZoneId.systemDefault() else UTC)
 }

--- a/src/main/kotlin/zoneddatetime/extensions/ZonedDateTimeAttributeExtensions.kt
+++ b/src/main/kotlin/zoneddatetime/extensions/ZonedDateTimeAttributeExtensions.kt
@@ -1,9 +1,8 @@
 package zoneddatetime.extensions
 
-import zoneddatetime.ZonedDateTimeUtil
 import java.time.ZonedDateTime
 
-fun ZonedDateTime.isInLeapYear(): Boolean = ZonedDateTimeUtil.isLeapYear(this.year)
+fun ZonedDateTime.isInLeapYear(): Boolean = YearUtil.isLeapYear(this.year)
 
 fun ZonedDateTime.isAtStartOfDay(): Boolean = this.isEqualTime(this.atStartOfDay())
 

--- a/src/test/kotlin/zoneddatetime/ZonedDateTimeUtilTest.kt
+++ b/src/test/kotlin/zoneddatetime/ZonedDateTimeUtilTest.kt
@@ -1,8 +1,20 @@
 package zoneddatetime
 
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import zoneddatetime.extensions.getMonthBaseZero
 import java.time.ZonedDateTime
+import java.util.Calendar
+import java.util.Calendar.HOUR
+import java.util.Calendar.DAY_OF_MONTH
+import java.util.Calendar.MILLISECOND
+import java.util.Calendar.MINUTE
+import java.util.Calendar.MONTH
+import java.util.Calendar.SECOND
+import java.util.Calendar.YEAR
+import java.util.Date
+import java.util.GregorianCalendar
+import java.util.TimeZone
 
 class ZonedDateTimeTest {
 
@@ -54,6 +66,137 @@ class ZonedDateTimeTest {
         assertEquals(minute, dateFormed.minute)
         assertEquals(second, dateFormed.second)
         assertEquals(0, dateFormed.nano)
+    }
+
+    @Test
+    fun `given date day month year & time in AM, when converted to date, then should match attributes`() {
+        // given
+        val day = 7
+        val month = 6
+        val year = 2021
+        val hour = 7
+        val hourInAm = true
+        val minute = 35
+        val second = 45
+
+        // when
+        val dateFormed: ZonedDateTime = ZonedDateTimeUtil.new(
+            year = year,
+            month = month,
+            day = day,
+            hour = hour,
+            isAm = hourInAm,
+            minute = minute,
+            second = second
+        )
+
+        // then
+        assertEquals(day, dateFormed.dayOfMonth)
+        assertEquals(month, dateFormed.month.value)
+        assertEquals(year, dateFormed.year)
+        assertEquals(hour, dateFormed.hour)
+        assertEquals(minute, dateFormed.minute)
+        assertEquals(second, dateFormed.second)
+        assertEquals(0, dateFormed.nano)
+    }
+
+    @Test
+    fun `given date day month year & time in PM, when converted to date, then should match attributes`() {
+        // given
+        val day = 7
+        val month = 6
+        val year = 2021
+        val hour = 7
+        val hourInAm = false
+        val minute = 35
+        val second = 45
+
+        // when
+        val dateFormed: ZonedDateTime = ZonedDateTimeUtil.new(
+            year = year,
+            month = month,
+            day = day,
+            hour = hour,
+            isAm = hourInAm,
+            minute = minute,
+            second = second
+        )
+
+        // then
+        assertEquals(day, dateFormed.dayOfMonth)
+        assertEquals(month, dateFormed.month.value)
+        assertEquals(year, dateFormed.year)
+        assertEquals(hour + 12, dateFormed.hour)
+        assertEquals(minute, dateFormed.minute)
+        assertEquals(second, dateFormed.second)
+        assertEquals(0, dateFormed.nano)
+    }
+
+    @Test
+    fun `given date day month year & time with calendar, when converted to zonedDateTime, then should match attributes`() {
+        // given
+        val day = 7
+        val month = 6
+        val year = 2021
+        val hour = 7
+        val minute = 35
+        val second = 45
+        val timeZoneId = "GMT"
+
+        // when
+        val calendar = Calendar.getInstance().apply {
+            timeZone = TimeZone.getTimeZone(timeZoneId)
+            set(year, month, day, hour, minute, second)
+        }
+        val zonedDateTime = ZonedDateTimeUtil.new(calendar, useSystemTimeZone = false)
+
+        // then
+        assertEquals(calendar.timeZone.id, zonedDateTime.zone.id)
+        assertEquals(calendar[YEAR], zonedDateTime.year)
+        assertEquals(calendar[MONTH], zonedDateTime.getMonthBaseZero())
+        assertEquals(calendar[DAY_OF_MONTH], zonedDateTime.dayOfMonth)
+        assertEquals(calendar[HOUR], zonedDateTime.hour)
+        assertEquals(calendar[MINUTE], zonedDateTime.minute)
+        assertEquals(calendar[SECOND], zonedDateTime.second)
+        assertEquals(calendar[MILLISECOND], zonedDateTime.toLocalTime().nano/1000000)
+    }
+
+    @Test
+    fun `given date epoch millisecond of Date, when converted to zonedDateTime, then should match attributes`() {
+        // given
+        val epoch = 1325134800000
+
+        // when
+        val date = Date(epoch)
+        val zonedDateTime = ZonedDateTimeUtil.new(epoch, useSystemTimeZone = false)
+
+        // then
+        assertEquals(date.time, zonedDateTime.toInstant().toEpochMilli())
+    }
+
+    @Test
+    fun `given date epoch millisecond of Date & UTC timezone, when converted to zonedDateTime, then should match attributes`() {
+        // given
+        val epoch = 1325134800000
+        val defaultTimeZoneId = "UTC"
+
+        // when
+        val date = Date(epoch)
+        val zonedDateTime = ZonedDateTimeUtil.new(epoch, useSystemTimeZone = false)
+        val calendar = GregorianCalendar().apply {
+            timeZone = TimeZone.getTimeZone(defaultTimeZoneId)
+            time = date
+        }
+
+        // then
+        assertEquals(date.time, zonedDateTime.toInstant().toEpochMilli())
+        assertEquals(calendar[YEAR], zonedDateTime.year)
+        assertEquals(calendar[MONTH], zonedDateTime.getMonthBaseZero())
+        assertEquals(calendar[DAY_OF_MONTH], zonedDateTime.dayOfMonth)
+        assertEquals(calendar[HOUR], zonedDateTime.hour)
+        assertEquals(calendar[MINUTE], zonedDateTime.minute)
+        assertEquals(calendar[SECOND], zonedDateTime.second)
+        assertEquals(calendar[MILLISECOND], zonedDateTime.toLocalTime().nano/1000000)
     }
 
 }


### PR DESCRIPTION
- Add more new ZonedDateTime methods:
	- Using Calendar.
	- Using Date.
	- Capability to default to systemTimeZone or leave as UTC.
- Refactor to use YearUtil.
- Add JavaDoc documentation.