### PR TITLE
Add `plusMillis` and `minusMillis` extensions for LocalTime, LocalDateTime, and ZonedDateTime 

### DIFF
--- a/src/main/kotlin/javatimefun/localdatetime/extensions/LocalDateTimeMutatingExtensions.kt
+++ b/src/main/kotlin/javatimefun/localdatetime/extensions/LocalDateTimeMutatingExtensions.kt
@@ -5,7 +5,12 @@ import java.time.DayOfWeek
 import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.ZoneId
+import java.time.temporal.ChronoUnit
 import java.time.temporal.TemporalAdjusters
+
+fun LocalDateTime.plusMillis(millis: Long): LocalDateTime = this.plus(millis, ChronoUnit.MILLIS)
+
+fun LocalDateTime.minusMillis(millis: Long): LocalDateTime = this.minus(millis, ChronoUnit.MILLIS)
 
 fun LocalDateTime.atStartOfDay(): LocalDateTime = this.withLocalTime(LocalTime.MIN)
 

--- a/src/main/kotlin/javatimefun/localtime/extensions/LocalTimeMutatingExtensions.kt
+++ b/src/main/kotlin/javatimefun/localtime/extensions/LocalTimeMutatingExtensions.kt
@@ -1,0 +1,18 @@
+package javatimefun.localtime.extensions
+
+import java.time.LocalTime
+import java.time.temporal.ChronoUnit
+
+/**
+ * Works off of LocalTime context. Wraps around midnight, e.g. 23:59:59.999 + 1ms -> 00:00:00.
+ * @param millis  Number of milliseconds to add (may be negative).
+ * @return  LocalTime advanced by the given milliseconds.
+ */
+fun LocalTime.plusMillis(millis: Long): LocalTime = this.plus(millis, ChronoUnit.MILLIS)
+
+/**
+ * Works off of LocalTime context. Wraps around midnight, e.g. 00:00:00 - 1ms -> 23:59:59.999.
+ * @param millis  Number of milliseconds to subtract (may be negative).
+ * @return  LocalTime moved back by the given milliseconds.
+ */
+fun LocalTime.minusMillis(millis: Long): LocalTime = this.minus(millis, ChronoUnit.MILLIS)

--- a/src/main/kotlin/javatimefun/zoneddatetime/extensions/ZonedDateTimeMutatingExtensions.kt
+++ b/src/main/kotlin/javatimefun/zoneddatetime/extensions/ZonedDateTimeMutatingExtensions.kt
@@ -3,7 +3,22 @@ package javatimefun.zoneddatetime.extensions
 import java.time.DayOfWeek
 import java.time.LocalTime
 import java.time.ZonedDateTime
+import java.time.temporal.ChronoUnit
 import java.time.temporal.TemporalAdjusters
+
+/**
+ * Works off of ZonedDateTime context.
+ * @param millis  Number of milliseconds to add (may be negative).
+ * @return  ZonedDateTime advanced by the given milliseconds.
+ */
+fun ZonedDateTime.plusMillis(millis: Long): ZonedDateTime = this.plus(millis, ChronoUnit.MILLIS)
+
+/**
+ * Works off of ZonedDateTime context.
+ * @param millis  Number of milliseconds to subtract (may be negative).
+ * @return  ZonedDateTime moved back by the given milliseconds.
+ */
+fun ZonedDateTime.minusMillis(millis: Long): ZonedDateTime = this.minus(millis, ChronoUnit.MILLIS)
 
 /**
  * Works off of ZonedDateTime context.

--- a/src/test/kotlin/localdatetime/LocalDateTimeMutatingTest.kt
+++ b/src/test/kotlin/localdatetime/LocalDateTimeMutatingTest.kt
@@ -6,11 +6,47 @@ import javatimefun.localdatetime.extensions.atStartOfMonth
 import javatimefun.localdatetime.extensions.fromUtcToZone
 import javatimefun.localdatetime.extensions.fromZoneToUtc
 import javatimefun.localdatetime.extensions.fromZoneToZone
+import javatimefun.localdatetime.extensions.minusMillis
+import javatimefun.localdatetime.extensions.plusMillis
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import java.time.LocalDateTime
 
 class LocalDateTimeMutatingTest {
+    @Test
+    fun `plusMillis adds milliseconds as nanos`() {
+        val dateTime = LocalDateTime.of(2025, 6, 15, 12, 0, 0, 0)
+        val result = dateTime.plusMillis(500)
+
+        assertEquals(12, result.hour)
+        assertEquals(0, result.minute)
+        assertEquals(0, result.second)
+        assertEquals(500_000_000, result.nano)
+    }
+
+    @Test
+    fun `plusMillis rolls over into the next second`() {
+        val dateTime = LocalDateTime.of(2025, 6, 15, 12, 0, 0, 800_000_000)
+        val result = dateTime.plusMillis(500)
+
+        assertEquals(1, result.second)
+        assertEquals(300_000_000, result.nano)
+    }
+
+    @Test
+    fun `minusMillis is the inverse of plusMillis`() {
+        val dateTime = LocalDateTime.of(2025, 6, 15, 12, 0, 0, 0)
+
+        assertEquals(dateTime, dateTime.plusMillis(750).minusMillis(750))
+    }
+
+    @Test
+    fun `plusMillis with negative argument behaves like minusMillis`() {
+        val dateTime = LocalDateTime.of(2025, 6, 15, 12, 0, 0, 0)
+
+        assertEquals(dateTime.minusMillis(250), dateTime.plusMillis(-250))
+    }
+
     @Test
     fun `atStartOfMonth sets time to first day of month at start of day`() {
         val dateTime = LocalDateTime.of(2025, 6, 15, 12, 30)

--- a/src/test/kotlin/localtime/LocalTimeMutatingTest.kt
+++ b/src/test/kotlin/localtime/LocalTimeMutatingTest.kt
@@ -1,0 +1,50 @@
+package localtime
+
+import javatimefun.localtime.extensions.minusMillis
+import javatimefun.localtime.extensions.plusMillis
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.time.LocalTime
+
+class LocalTimeMutatingTest {
+    @Test
+    fun `plusMillis adds milliseconds as nanos`() {
+        val time = LocalTime.of(12, 0, 0, 0)
+        val result = time.plusMillis(500)
+
+        assertEquals(12, result.hour)
+        assertEquals(0, result.minute)
+        assertEquals(0, result.second)
+        assertEquals(500_000_000, result.nano)
+    }
+
+    @Test
+    fun `plusMillis rolls over into the next second`() {
+        val time = LocalTime.of(12, 0, 0, 800_000_000)
+        val result = time.plusMillis(500)
+
+        assertEquals(1, result.second)
+        assertEquals(300_000_000, result.nano)
+    }
+
+    @Test
+    fun `minusMillis is the inverse of plusMillis`() {
+        val time = LocalTime.of(12, 0, 0, 0)
+
+        assertEquals(time, time.plusMillis(750).minusMillis(750))
+    }
+
+    @Test
+    fun `plusMillis with negative argument behaves like minusMillis`() {
+        val time = LocalTime.of(12, 0, 0, 0)
+
+        assertEquals(time.minusMillis(250), time.plusMillis(-250))
+    }
+
+    @Test
+    fun `plusMillis wraps around midnight`() {
+        val time = LocalTime.of(23, 59, 59, 999_000_000)
+
+        assertEquals(LocalTime.MIDNIGHT, time.plusMillis(1))
+    }
+}

--- a/src/test/kotlin/zoneddatetime/ZonedDateTimeMutatingExtensionsTest.kt
+++ b/src/test/kotlin/zoneddatetime/ZonedDateTimeMutatingExtensionsTest.kt
@@ -14,6 +14,8 @@ import javatimefun.zoneddatetime.extensions.withLocalTime
 import javatimefun.zoneddatetime.extensions.atStartOfMonth
 import javatimefun.zoneddatetime.extensions.atEndOfMonth
 import javatimefun.zoneddatetime.extensions.atStartOfDay
+import javatimefun.zoneddatetime.extensions.minusMillis
+import javatimefun.zoneddatetime.extensions.plusMillis
 import java.time.DayOfWeek
 import java.time.LocalTime
 
@@ -21,6 +23,53 @@ class ZonedDateTimeMutatingExtensionsTest {
 
     companion object {
         private const val HH_MM_SS_AM = "hh:mm:ss a"
+    }
+
+    @Test
+    fun `given date, when adding milliseconds, then should advance nanos`() {
+        // given
+        val date = ZonedDateTimeFactory.new(2025, 6, 15, hourIn24 = 12)
+
+        // when
+        val result = date.plusMillis(500)
+
+        // then
+        Assertions.assertEquals(0, result.second)
+        Assertions.assertEquals(500_000_000, result.nano)
+    }
+
+    @Test
+    fun `given date near a second boundary, when adding milliseconds, then should roll over`() {
+        // given
+        val date = ZonedDateTimeFactory.new(2025, 6, 15, hourIn24 = 12, nano = 800_000_000)
+
+        // when
+        val result = date.plusMillis(500)
+
+        // then
+        Assertions.assertEquals(1, result.second)
+        Assertions.assertEquals(300_000_000, result.nano)
+    }
+
+    @Test
+    fun `given date, when subtracting after adding milliseconds, then should return original`() {
+        // given
+        val date = ZonedDateTimeFactory.new(2025, 6, 15, hourIn24 = 12)
+
+        // when
+        val result = date.plusMillis(750).minusMillis(750)
+
+        // then
+        Assertions.assertEquals(date, result)
+    }
+
+    @Test
+    fun `given date, when adding negative milliseconds, then should behave like minusMillis`() {
+        // given
+        val date = ZonedDateTimeFactory.new(2025, 6, 15, hourIn24 = 12)
+
+        // when & then
+        Assertions.assertEquals(date.minusMillis(250), date.plusMillis(-250))
     }
 
     @Test


### PR DESCRIPTION

Add `plusMillis` and `minusMillis` extensions for LocalTime, LocalDateTime, and ZonedDateTime 